### PR TITLE
Needs to generate a unique ID for Docker

### DIFF
--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -74,6 +74,8 @@ def id() -> str:
     id = __read__('/var/lib/dbus/machine-id')
     if not id:
       id = __read__('/etc/machine-id')
+    if not id:
+      id = __read__('/sys/class/net/eth0/address')
 
   if platform.startswith('openbsd') or platform.startswith('freebsd'):
     id = __read__('/etc/hostid')


### PR DESCRIPTION
One way to generate a unique ID on a **Docker**, is to get the *first* ethernet MAC address.
Here is more information: https://stackoverflow.com/a/48651560/3780957.
The MAC address is stored in this file: `cat /sys/class/net/eth0/address`