### PR TITLE
Add an id for Docker containers

### DIFF
--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -75,13 +75,13 @@ def id() -> str:
     if not id:
       id = __read__('/etc/machine-id')
     if not id:
-        cgroup = __read__('/proc/self/cgroup')
-        if 'docker' in cgroup:
-            id = __exec__('head -1 /proc/self/cgroup | cut -d/ -f3')
+      cgroup = __read__('/proc/self/cgroup')
+      if 'docker' in cgroup:
+        id = __exec__('head -1 /proc/self/cgroup | cut -d/ -f3')
     if not id:
-        mountinfo = __read__('/proc/self/mountinfo')
-        if 'docker' in mountinfo:
-            id = __exec__("grep 'systemd' /proc/self/mountinfo | cut -d/ -f3")
+      mountinfo = __read__('/proc/self/mountinfo')
+      if 'docker' in mountinfo:
+        id = __exec__("grep 'systemd' /proc/self/mountinfo | cut -d/ -f3")
 
   if platform.startswith('openbsd') or platform.startswith('freebsd'):
     id = __read__('/etc/hostid')

--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -76,12 +76,14 @@ def id() -> str:
       id = __read__('/etc/machine-id')
     if not id:
       cgroup = __read__('/proc/self/cgroup')
-      if 'docker' in cgroup:
-        id = __exec__('head -1 /proc/self/cgroup | cut -d/ -f3')
+      if cgroup:
+        if 'docker' in cgroup:
+          id = __exec__('head -1 /proc/self/cgroup | cut -d/ -f3')
     if not id:
       mountinfo = __read__('/proc/self/mountinfo')
-      if 'docker' in mountinfo:
-        id = __exec__("grep 'systemd' /proc/self/mountinfo | cut -d/ -f3")
+      if mountinfo:
+        if 'docker' in mountinfo:
+          id = __exec__("grep 'systemd' /proc/self/mountinfo | cut -d/ -f3")
 
   if platform.startswith('openbsd') or platform.startswith('freebsd'):
     id = __read__('/etc/hostid')

--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -75,10 +75,14 @@ def id() -> str:
     if not id:
       id = __read__('/etc/machine-id')
     if not id:
-      id = __exec__('head -1 /proc/self/cgroup|cut -d/ -f3')
+        cgroup = __read__('/proc/self/cgroup')
+        if 'docker' in cgroup:
+            id = __exec__('head -1 /proc/self/cgroup | cut -d/ -f3')
     if not id:
-      id = __exec__("grep 'systemd' /proc/self/mountinfo|cut -d/ -f3")
-    
+        mountinfo = __read__('/proc/self/mountinfo')
+        if 'docker' in mountinfo:
+            id = __exec__("grep 'systemd' /proc/self/mountinfo | cut -d/ -f3")
+
   if platform.startswith('openbsd') or platform.startswith('freebsd'):
     id = __read__('/etc/hostid')
     if not id:

--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -74,7 +74,11 @@ def id() -> str:
     id = __read__('/var/lib/dbus/machine-id')
     if not id:
       id = __read__('/etc/machine-id')
-
+    if not id:
+      id = __exec__('head -1 /proc/self/cgroup|cut -d/ -f3')
+    if not id:
+      id = __exec__("grep 'systemd' /proc/self/mountinfo|cut -d/ -f3")
+    
   if platform.startswith('openbsd') or platform.startswith('freebsd'):
     id = __read__('/etc/hostid')
     if not id:


### PR DESCRIPTION
Usual Linux images for Docker containers, does not have the originally listed files. Following the conversation at https://github.com/denisbrodbeck/machineid/issues/10, I am including the following: Because `/proc/self/cgroup` seams to not be working on same Docker versions, I am also including `/proc/self/mountinfo`.

Tested on `Python 3.11` running on `Debian GNU/Linux 11 (bullseye)` inside a Docker.