### PR TITLE
Adding a Uniform Format Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ print(machineid.hashed_id('myappid'))
 print(machineid.hashed_id())
 ```
 
+To obtain the machine ID for consistency across platforms, use `uuid_formatted_id() -> str`
+
+```python
+import machineid
+
+print(machineid.uuid_formatted_id())
+```
+
 ## Thanks
 
 Special thanks to Denis Brodbeck for his Go package, [`machineid`](https://github.com/denisbrodbeck/machineid).

--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -122,5 +122,8 @@ def hashed_id(app_id: str = "", **kwargs) -> str:
 
 
 def uuid_formatted_id() -> str:
+    """
+    uuid_formatted_id returns a UUID-compliant machineid
+    """
     mykdf = hashlib.pbkdf2_hmac("sha256", id().encode("utf-8"), b"", 10**6, dklen=16)
     return str(UUID(bytes=mykdf)).upper()

--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -17,6 +17,11 @@ You can anonymize the ID like so, with an optional app ID:
     >>> machine.hashed_id()
     ce2127ade536eaa9529f4a7b73141bbc2f094c46e32742c97679e186e7f13fde
 
+You can also format the machine ID for consistency across platforms using this method:
+    >>> import machineid
+    >>> machineid.uuid_formatted_id()
+    DA21FFE3-A1F4-CC23-861F-9B29B2BF2F56
+
 Special thanks to Denis Brodbeck for his Go package, machineid (https://github.com/denisbrodbeck/machineid).
 
 :license: MIT, see LICENSE for more details.
@@ -123,7 +128,7 @@ def hashed_id(app_id: str = "", **kwargs) -> str:
 
 def uuid_formatted_id() -> str:
     """
-    uuid_formatted_id returns a UUID-compliant machineid
+    uuid_formatted_id returns cross-platform machineid
     """
     mykdf = hashlib.pbkdf2_hmac("sha256", id().encode("utf-8"), b"", 10**6, dklen=16)
     return str(UUID(bytes=mykdf)).upper()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,19 +1,37 @@
 from sys import platform
+from uuid import UUID
 
 import machineid
 import unittest
 
+
 class TestMachineId(unittest.TestCase):
-  def test_hashed_id(self):
-    self.assertTrue(isinstance(machineid.hashed_id(), str))
-    self.assertTrue(len(machineid.hashed_id()) > 0)
-    self.assertTrue(machineid.hashed_id('foo') != machineid.hashed_id('bar'))
-    self.assertTrue(machineid.hashed_id('foo') != machineid.hashed_id())
+    def uuid_formatted_id(self):
+        self.assertTrue(isinstance(machineid.uuid_formatted_id(), str))
+        self.assertTrue(len(machineid.uuid_formatted_id()) > 0)
+        self.assertTrue(
+            machineid.uuid_formatted_id("foo") != machineid.uuid_formatted_id("bar")
+        )
+        self.assertTrue(
+            machineid.uuid_formatted_id("foo") != machineid.uuid_formatted_id()
+        )
+        uuid_set = set()
+        for _ in range(100):
+            uuid_set.add(machineid.uuid_formatted_id())
+        self.assertEqual(len(uuid_set), 100)
+        self.assertIsInstance(UUID(machineid.uuid_formatted_id().lower), UUID)
 
-  def test_id(self):
-    self.assertTrue(isinstance(machineid.id(), str))
-    self.assertTrue(len(machineid.id()) > 0)
-    self.assertTrue(machineid.id() != machineid.hashed_id())
+    def test_hashed_id(self):
+        self.assertTrue(isinstance(machineid.hashed_id(), str))
+        self.assertTrue(len(machineid.hashed_id()) > 0)
+        self.assertTrue(machineid.hashed_id("foo") != machineid.hashed_id("bar"))
+        self.assertTrue(machineid.hashed_id("foo") != machineid.hashed_id())
 
-if __name__ == '__main__':
-  unittest.main()
+    def test_id(self):
+        self.assertTrue(isinstance(machineid.id(), str))
+        self.assertTrue(len(machineid.id()) > 0)
+        self.assertTrue(machineid.id() != machineid.hashed_id())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 As you may know, machineid is often used to generate globally unique serial numbers such as order number, flow number, transaction version number. Therefore, it would be helpful to have a standardized format for the output, and the hashed_id you provide may not suit many scenarios. I think the uuid format is a good option, and I have written a demo for you.You can amend the code according to your preferences and requirements.