### PR TITLE
Syntax warning because of "\S" in Python 3.12

### DIFF
--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -67,7 +67,7 @@ def id(winregistry: bool = True) -> str:
     id = __exec__("ioreg -d2 -c IOPlatformExpertDevice | awk -F\\\" '/IOPlatformUUID/{print $(NF-1)}'")
   elif platform == 'win32' or platform == 'cygwin' or platform == 'msys':
     if winregistry:
-      id = __reg__('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography', 'MachineGuid')
+      id = __reg__(r'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography', 'MachineGuid')
     else:
       id = __exec__("powershell.exe -ExecutionPolicy bypass -command (Get-CimInstance -Class Win32_ComputerSystemProduct).UUID")
     if not id:


### PR DESCRIPTION
Close #9