### PR TITLE
Code simplifications

### DIFF
--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -87,7 +87,7 @@ def id(winregistry: bool = True) -> str:
         id = __exec__("grep -oP '(?<=docker/containers/)([a-f0-9]+)(?=/hostname)' /proc/self/mountinfo")
     if not id and 'microsoft' in uname().release: # wsl
       id = __exec__("powershell.exe -ExecutionPolicy bypass -command '(Get-CimInstance -Class Win32_ComputerSystemProduct).UUID'")
-  elif platform.startswith('openbsd') or platform.startswith('freebsd'):
+  elif platform.startswith(('openbsd', 'freebsd')):
     id = __read__('/etc/hostid')
     if not id:
       id = __exec__('kenv -q smbios.system.uuid')

--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -62,7 +62,7 @@ def id(winregistry: bool = True) -> str:
   """
   id returns the platform specific device GUID of the current host OS.
   """
-
+  id = None
   if platform == 'darwin':
     id = __exec__("ioreg -d2 -c IOPlatformExpertDevice | awk -F\\\" '/IOPlatformUUID/{print $(NF-1)}'")
   elif platform == 'win32' or platform == 'cygwin' or platform == 'msys':

--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -65,7 +65,7 @@ def id(winregistry: bool = True) -> str:
   id = None
   if platform == 'darwin':
     id = __exec__("ioreg -d2 -c IOPlatformExpertDevice | awk -F\\\" '/IOPlatformUUID/{print $(NF-1)}'")
-  elif platform == 'win32' or platform == 'cygwin' or platform == 'msys':
+  elif platform in ('win32', 'cygwin', 'msys'):
     if winregistry:
       id = __reg__(r'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography', 'MachineGuid')
     else:

--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -79,17 +79,14 @@ def id(winregistry: bool = True) -> str:
       id = __read__('/etc/machine-id')
     if not id:
       cgroup = __read__('/proc/self/cgroup')
-      if cgroup:
-        if 'docker' in cgroup:
-          id = __exec__('head -1 /proc/self/cgroup | cut -d/ -f3')
+      if cgroup and 'docker' in cgroup:
+        id = __exec__('head -1 /proc/self/cgroup | cut -d/ -f3')
     if not id:
       mountinfo = __read__('/proc/self/mountinfo')
-      if mountinfo:
-        if 'docker' in mountinfo:
-          id = __exec__("grep -oP '(?<=docker/containers/)([a-f0-9]+)(?=/hostname)' /proc/self/mountinfo")
-    if not id:
-      if 'microsoft' in uname().release: # wsl
-        id = __exec__("powershell.exe -ExecutionPolicy bypass -command '(Get-CimInstance -Class Win32_ComputerSystemProduct).UUID'")
+      if mountinfo and 'docker' in mountinfo:
+        id = __exec__("grep -oP '(?<=docker/containers/)([a-f0-9]+)(?=/hostname)' /proc/self/mountinfo")
+    if not id and 'microsoft' in uname().release: # wsl
+      id = __exec__("powershell.exe -ExecutionPolicy bypass -command '(Get-CimInstance -Class Win32_ComputerSystemProduct).UUID'")
   elif platform.startswith('openbsd') or platform.startswith('freebsd'):
     id = __read__('/etc/hostid')
     if not id:


### PR DESCRIPTION
Here are some code simplifications that may be interesting:
* some nested "if" condition can be avoided;
* the `startswith` condition can be simplified;
* several 'or' can be simplified in a single 'in' condition;
* the `id` variable may be used before being assigned. In this case, the `id` built-in function is retrieved…