### PR TITLE
Sanitize id() output

### DIFF
--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -31,6 +31,7 @@ from sys import platform
 import subprocess
 import hashlib
 import hmac
+import re
 
 def __exec__(cmd: str) -> str:
   try:
@@ -95,7 +96,8 @@ def id(winregistry: bool = True) -> str:
   if not id:
     raise Exception('failed to obtain id on platform {}'.format(platform))
 
-  return id
+  # Make sure we always return a single line without control characters
+  return re.sub(r"[\x00-\x1f\x7f-\x9f]", "", str(id).split('\n')[0])
 
 def hashed_id(app_id: str = '', **kwargs) -> str:
   """


### PR DESCRIPTION
On some systems, `id()` might return a string ending with `\n`. Perhaps even a multiline string.

This patch makes sure output is a sanitized oneliner.

Before patch
```
Python 3.9.18 (main, Sep  7 2023, 00:00:00)
[GCC 11.4.1 20230605 (Red Hat 11.4.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import machineid
>>> machineid.id()
'c9f343fb992a4b9cb183fcefe6668da2\n'
```

After patch
```
Python 3.9.18 (main, Sep  7 2023, 00:00:00)
[GCC 11.4.1 20230605 (Red Hat 11.4.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import machineid
>>> machineid.id()
'c9f343fb992a4b9cb183fcefe6668da2'
```