### PR TITLE
Raise and catch specific errors

### DIFF
--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -30,16 +30,12 @@ import hashlib
 import hmac
 import re
 import subprocess
-from logging import getLogger
 from platform import uname
 from sys import platform
-
-log = getLogger(__name__)
 
 try:
   from winregistry import WinRegistry
 except ImportError:
-  log.debug("winregistry not available.")
   WinRegistry = None
 
 
@@ -60,8 +56,7 @@ def __exec__(cmd: str) -> str:
     return subprocess.run(cmd, shell=True, capture_output=True, check=True, encoding='utf-8') \
                      .stdout \
                      .strip()
-  except subprocess.SubprocessError as err:
-    log.debug(err)
+  except subprocess.SubprocessError:
     return None
 
 def __read__(path: str) -> str:
@@ -69,8 +64,7 @@ def __read__(path: str) -> str:
     with open(path) as f:
       return f.read() \
               .strip()
-  except IOError as err:
-    log.debug(err)
+  except IOError:
     return None
 
 def __reg__(registry: str, key: str) -> str:
@@ -79,8 +73,7 @@ def __reg__(registry: str, key: str) -> str:
       return reg.read_entry(registry, key) \
                 .value \
                 .strip()
-  except OSError as err:
-    log.debug(err)
+  except OSError:
     return None
 
 def id(winregistry: bool = True) -> str:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,59 @@
+import subprocess
+import unittest
+from unittest.mock import MagicMock, Mock, mock_open, patch
+
+import machineid
+
+RETURNS_NONE = Mock(return_value=None)
+CALL_FAILURE = Mock(side_effect=subprocess.CalledProcessError(
+  cmd='powershell.exe',
+  returncode=1)
+)
+WINREG_ERROR = MagicMock()
+WINREG_ERROR.return_value.__enter__.return_value.read_entry.side_effect = OSError()
+
+class TestExceptionsHandling(unittest.TestCase):
+  @patch.multiple(
+    'machineid',
+    __exec__=RETURNS_NONE,
+    __read__=RETURNS_NONE,
+    __reg__=RETURNS_NONE,
+  )
+  def test_raises_custom_error(self):
+    with self.assertRaises(machineid.MachineIdNotFound):
+      machineid.id()
+
+  @patch.multiple(
+    'machineid',
+    __exec__=RETURNS_NONE,
+    __read__=RETURNS_NONE,
+  )
+  def test_logs_winreg_error(self):
+    with patch('machineid.WinRegistry', WINREG_ERROR):
+      with self.assertLogs(machineid.log, level='DEBUG'):
+        result = machineid.__reg__(r'HKEY_LOCAL_MACHINE\TEST', 'TEST')
+        self.assertIsNone(result)
+
+  @patch.multiple(
+    'machineid',
+    __exec__=RETURNS_NONE,
+    __reg__=RETURNS_NONE,
+  )
+  def test_logs_read_error(self):
+    with patch('builtins.open', mock_open()) as fake_open:
+      fake_open.side_effect = IOError()
+      with self.assertLogs(machineid.log, level='DEBUG'):
+        result = machineid.__read__('/tmp/testfile')
+        self.assertIsNone(result)
+
+  @patch.multiple(
+    'machineid',
+    __read__=RETURNS_NONE,
+    __reg__=RETURNS_NONE,
+  )
+  def test_logs_exec_error(self):
+    with patch('machineid.subprocess.call', CALL_FAILURE):
+      with self.assertLogs(machineid.log, level='DEBUG'):
+        result = machineid.__exec__('powershell.exe doTest')
+        self.assertIsNone(result)
+

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,18 +1,14 @@
-import subprocess
 import unittest
-from unittest.mock import MagicMock, Mock, mock_open, patch
+from unittest.mock import Mock, patch
 
 import machineid
 
+
 RETURNS_NONE = Mock(return_value=None)
-CALL_FAILURE = Mock(side_effect=subprocess.CalledProcessError(
-  cmd='powershell.exe',
-  returncode=1)
-)
-WINREG_ERROR = MagicMock()
-WINREG_ERROR.return_value.__enter__.return_value.read_entry.side_effect = OSError()
+
 
 class TestExceptionsHandling(unittest.TestCase):
+
   @patch.multiple(
     'machineid',
     __exec__=RETURNS_NONE,
@@ -22,38 +18,3 @@ class TestExceptionsHandling(unittest.TestCase):
   def test_raises_custom_error(self):
     with self.assertRaises(machineid.MachineIdNotFound):
       machineid.id()
-
-  @patch.multiple(
-    'machineid',
-    __exec__=RETURNS_NONE,
-    __read__=RETURNS_NONE,
-  )
-  def test_logs_winreg_error(self):
-    with patch('machineid.WinRegistry', WINREG_ERROR):
-      with self.assertLogs(machineid.log, level='DEBUG'):
-        result = machineid.__reg__(r'HKEY_LOCAL_MACHINE\TEST', 'TEST')
-        self.assertIsNone(result)
-
-  @patch.multiple(
-    'machineid',
-    __exec__=RETURNS_NONE,
-    __reg__=RETURNS_NONE,
-  )
-  def test_logs_read_error(self):
-    with patch('builtins.open', mock_open()) as fake_open:
-      fake_open.side_effect = IOError()
-      with self.assertLogs(machineid.log, level='DEBUG'):
-        result = machineid.__read__('/tmp/testfile')
-        self.assertIsNone(result)
-
-  @patch.multiple(
-    'machineid',
-    __read__=RETURNS_NONE,
-    __reg__=RETURNS_NONE,
-  )
-  def test_logs_exec_error(self):
-    with patch('machineid.subprocess.call', CALL_FAILURE):
-      with self.assertLogs(machineid.log, level='DEBUG'):
-        result = machineid.__exec__('powershell.exe doTest')
-        self.assertIsNone(result)
-


### PR DESCRIPTION
This PR aims to improve the way exceptions are handled.
- Avoids [bare except](https://stackoverflow.com/questions/54948548/what-is-wrong-with-using-a-bare-except) catching.
- Raises a `MachineIdNotFound()` so calling applications can catch that instead of a generic `Exception`.
- Adds a unit tests to see we're throwing `MachineIdNotFound`.