### PR TITLE
docs(readme): update sponsor `ref` query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Get the unique machine ID of any host (without admin privileges).
 
 Sponsored by:
 
-<a href="https://keygen.sh?ref=typed_params">
+<a href="https://keygen.sh?ref=py-machineid">
   <div>
     <img src="https://keygen.sh/images/logo-pill.png" width="200" alt="Keygen">
   </div>


### PR DESCRIPTION
Had the wrong repo (`typed_params`) previously.