### PR TITLE
Add check for kubernetes

### DIFF
--- a/machineid/__init__.py
+++ b/machineid/__init__.py
@@ -103,6 +103,8 @@ def id(winregistry: bool = True) -> str:
       mountinfo = __read__('/proc/self/mountinfo')
       if mountinfo and 'docker' in mountinfo:
         id = __exec__("grep -oP '(?<=docker/containers/)([a-f0-9]+)(?=/hostname)' /proc/self/mountinfo")
+    if not id:  # when running with kubernetes it returns the pod id
+        id = __read__('/etc/hostname')
     if not id and 'microsoft' in uname().release: # wsl
       id = __exec__("powershell.exe -ExecutionPolicy bypass -command '(Get-CimInstance -Class Win32_ComputerSystemProduct).UUID'")
   elif platform.startswith(('openbsd', 'freebsd')):


### PR DESCRIPTION
we found that in the case of containers running in kubernetes the library raised `MachineIdNotFound`. There the regex used for docker doesn't return anything. Instead we used the `/etc/hostname` that contains the pod name.

Not a kubernetes expert but seems that the containers inside the pod can be regenerated and using the container id is not very reliable as they are much more ephemeral. 

https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/


```
➜  rotki git:(docker/build-fix) ✗ kubectl -n rotki exec -it deploy/rotki -- sh

# cat /etc/hostname
rotki-759fdc47dd-bjgvd
#
➜  rotki git:(docker/build-fix) ✗ kubectl -n rotki get pods
NAME                     READY   STATUS    RESTARTS   AGE
rotki-759fdc47dd-bjgvd   1/1     Running   0          6m50s
```